### PR TITLE
Update condor_blacklist.sh

### DIFF
--- a/condor_blacklist.sh
+++ b/condor_blacklist.sh
@@ -1,20 +1,7 @@
 #!/bin/bash
-condor_q abaty  | grep sh | awk '{print "condor_q -l "$1" | grep RemoteHost"}'|bash|sed -e 's/^.*@/Machine!="/'>>temporary_blist.txt
-
+condor_q $USER  | grep $USER | awk '{print "condor_q -l "$1" | grep RemoteHost"}'|bash|sed -e 's/^.*@/Machine!="/'>>temporary_blist.txt
 echo "parsing blacklist to keep only 1 copy of each bad machine"
-for i in $(cat temporary_blist.txt); do
-  isdouble=0
-  for j in $(cat condor_blacklist.txt); do
-    if [ "$i" == "$j" ]
-      then
-      isdouble=1
-    fi
-  done
-  if [ $isdouble == 0 ]
-    then
-    echo $i>>condor_blacklist.txt
-    echo "Adding machine to black list:"$i
-  fi
-done
+cat condor_blacklist.txt >> temporary_blacklist.txt
+cat temporary_blacklist.txt | sort | uniq > condor_blacklist.txt
 
-rm temporary_blist.txt
+rm temporary_blist.txt 


### PR DESCRIPTION
change hardcoded user name to $USER which won't need to be changed. also changed the grep to look for $USER since sh won't match all (for example if filename is too long condor_q will truncate it and miss the sh, but $USER will always be there)

also proposing another way to keep one copy of each bad machine
